### PR TITLE
feat: Added some control flow

### DIFF
--- a/mariadb/templates/configmap.yaml
+++ b/mariadb/templates/configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
 data:
-  MYSQL_DATABASE: {{ .Values.persistence.dbName }}
-  MYSQL_USER: {{ .Values.persistence.dbUser }}
+  MYSQL_DATABASE: {{ .Values.database.dbName }}
+  MYSQL_USER: {{ .Values.database.dbUser }}

--- a/mariadb/templates/pvc.yaml
+++ b/mariadb/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.persistence.enabled -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -15,6 +16,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.mysqlDataSize }}
-  {{- if .Values.persistence.storageClassName -}}
+  {{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName | quote }}
   {{- end }}
+{{- end }}

--- a/mariadb/templates/secret.yaml
+++ b/mariadb/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "mariadb.labels" . | nindent 4 }}
 type: Opaque
 data:
-  MYSQL_ROOT_PASSWORD: {{ .Values.mysqlDbRootPassword | b64enc }}
-  MYSQL_PASSWORD: {{ .Values.mysqlDbPassword | b64enc }}
+  MYSQL_ROOT_PASSWORD: {{ .Values.database.dbRootPassword | b64enc }}
+  MYSQL_PASSWORD: {{ .Values.database.dbPassword | b64enc }}

--- a/mariadb/templates/service.yaml
+++ b/mariadb/templates/service.yaml
@@ -10,19 +10,8 @@ spec:
     - port: {{ .Values.service.port }}
       protocol: TCP
       name: mariadb
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "mariadb.selectorLabels" . | nindent 4 }}
-
-# spec:
-#   type: NodePort
-#   # type: ClusterIP
-#   ports:
-#     - name: mariadb
-#       port: 3306
-#       protocol: TCP
-#       # targetPort: 3306
-#       # nodePort: 30001
-#   selector:
-#     app.kubernetes.io/name: mariadb
-# status:
-#   loadBalancer: {}

--- a/mariadb/templates/statefulset.yaml
+++ b/mariadb/templates/statefulset.yaml
@@ -41,12 +41,16 @@ spec:
             - secretRef:
                 name: {{ include "mariadb.fullname" . }}
           volumeMounts:
+          {{- if .Values.persistence.enabled }}
             - mountPath: {{ .Values.persistence.mountPath }}
               name: "mariadb-data"
+          {{- end }}
       volumes:
+      {{- if .Values.persistence.enabled }}
         - name: "mariadb-data"
           persistentVolumeClaim:
             claimName: {{ include "mariadb.fullname" . }}
+      {{- end }}
       # securityContext:
       #   runAsUser: 27
       #   runAsGroup: 1000

--- a/mariadb/values.yaml
+++ b/mariadb/values.yaml
@@ -85,12 +85,14 @@ tolerations: []
 affinity: {}
 
 persistence:
+  enabled: true
   storageClassName: ""
-  dbName: glpi
-  dbUser: glpi
   mysqlDataSize: 3Gi
   mountPath: "/var/lib/mysql:Z"
   # mountPath: "/bitnami/mariadb:Z"
 
-mysqlDbPassword: admin123
-mysqlDbRootPassword: admin123
+database: 
+  dbName: mariadb
+  dbUser: mariadb
+  dbPassword: admin123
+  dbRootPassword: admin123

--- a/phpmyadmin/templates/service.yaml
+++ b/phpmyadmin/templates/service.yaml
@@ -11,5 +11,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "phpmyadmin.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Added some control flow to allow the deployment of mariadb throughout a NodePort.

Now it is possible to select the `type` of the service from the values file.
It is also possible to unset the creation of volumes.
